### PR TITLE
fix failing test

### DIFF
--- a/tests/writer/test_opensearch_writer.py
+++ b/tests/writer/test_opensearch_writer.py
@@ -14,6 +14,7 @@ def mock_config():
         "output": {
             "config": {
                 "host": "https://mock-host",
+                "port": 9200,
                 "index": "test_index",
                 "use_ssl": True,
                 "verify_certs": True,


### PR DESCRIPTION
- add OpenSearch port to mock config object to fix failing tests due to the addition of port to app output config